### PR TITLE
Always convert all start end times to UTC

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -11,6 +11,7 @@ from core.models import Query
 from django.utils import timezone
 import helpers
 import hashlib
+import pytz
 
 
 def index(request):
@@ -92,10 +93,12 @@ class Bookings(Events):
         return item["description"]
 
     def item_start(self, item):
-        return ciso8601.parse_datetime(item["start_time"])
+        start = ciso8601.parse_datetime(item["start_time"])
+        return start.astimezone(pytz.utc)
 
     def item_end(self, item):
-        return ciso8601.parse_datetime(item["end_time"])
+        end = ciso8601.parse_datetime(item["end_time"])
+        return end.astimezone(pytz.utc)
 
     def item_location(self, item):
         return item["roomname"]


### PR DESCRIPTION
this is due to how the ics format works. Times will be displayed in user’s local timezone